### PR TITLE
Use beautifulsoup4 instead of bs4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ asyncio_mode = 'strict'
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.11"
-bs4 = "^0.0.1"
+beautifulsoup4 = ">=4,<5"
 aiohttp = "^3.8.1"
 cchardet = "^2.1.7"
 requests = "^2.27.1"


### PR DESCRIPTION
`bs4` is only a dummy package for `beautifulsoup4`.