### PR TITLE
remove duplicate license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ license = "MIT"
 packages = [
     { include = "graphinder" }
 ]
-include = [
-    "LICENSE",
-]
 readme = "README.md"
 "homepage" = "https://escape.tech/"
 "repository" = "https://github.com/Escape-Technologies/graphinder"


### PR DESCRIPTION
The license file is included two times and one is at the wrong place.

If we take a look at the wheel dist, we can see there is `LICENSE` at the root and also `graphinder-1.11.5.dist-info/LICENSE`:

```
$ 7z l dist/graphinder-1.11.5-py3-none-any.whl | grep -i license
1980-01-01 00:00:00 .....         1118          661  LICENSE
1980-01-01 00:00:00 .....         1118          661  graphinder-1.11.5.dist-info/LICENSE
```

But this is an issue, because when you install it on your system, it deploys one of the license file on the root path of the python site package directory:

```
$ tar tvf graphinder-1.11.5-1-any.pkg.tar.zst | grep -i license
-rw-r--r-- root/root      1118 2022-11-25 11:27 usr/lib/python3.10/site-packages/LICENSE
-rw-r--r-- root/root      1118 2022-11-25 11:27 usr/lib/python3.10/site-packages/graphinder-1.11.5.dist-info/LICENSE
```

So by removing the LICENSE from include it will remove `usr/lib/python3.10/site-packages/LICENSE` but keep `usr/lib/python3.10/site-packages/graphinder-1.11.5.dist-info/LICENSE`.

Other packages like https://github.com/nikitastupin/clairvoyance/pull/55 have the same issue which conflicts and prevent installing new tools with the same issue.

```
error: failed to commit transaction (conflicting files)
clairvoyance: /usr/lib/python3.10/site-packages/LICENSE exists in filesystem (owned by crackmapexec)
```